### PR TITLE
Try/build query 2x

### DIFF
--- a/lib/filters/nested-filter.js
+++ b/lib/filters/nested-filter.js
@@ -25,7 +25,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 function nestedFilter(path, type, field) {
   var klass = _index2.default[type];
   var nestedField = path + '.' + field;
-  var filter = undefined;
+  var filter = void 0;
 
   if (!klass) {
     throw new Error('Filter type not found.', type);

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,6 +20,10 @@ var _clone = require('lodash/lang/clone');
 
 var _clone2 = _interopRequireDefault(_clone);
 
+var _isUndefined = require('lodash/lang/isUndefined');
+
+var _isUndefined2 = _interopRequireDefault(_isUndefined);
+
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _filters = require('./filters');
@@ -70,7 +74,13 @@ var BodyBuilder = function () {
 
   _createClass(BodyBuilder, [{
     key: 'build',
-    value: function build() {
+    value: function build(version) {
+      if (!(0, _isUndefined2.default)(version) && version === 'v2') return this._buildV2();
+      return this._buildV1();
+    }
+  }, {
+    key: '_buildV1',
+    value: function _buildV1() {
       var body = (0, _clone2.default)(this._body);
       var filters = this._filters;
       var queries = this._queries;
@@ -88,6 +98,29 @@ var BodyBuilder = function () {
 
       if (!(0, _isEmpty2.default)(aggregations)) {
         (0, _set2.default)(body, 'aggregations', aggregations);
+      }
+
+      return body;
+    }
+  }, {
+    key: '_buildV2',
+    value: function _buildV2() {
+      var body = (0, _clone2.default)(this._body);
+      var filters = this._filters;
+      var queries = this._queries;
+      var aggregations = this._aggregations;
+
+      if (!(0, _isEmpty2.default)(filters)) {
+        (0, _set2.default)(body, 'query.bool.filter', filters);
+        if (!(0, _isEmpty2.default)(queries)) {
+          (0, _set2.default)(body, 'query.bool.must', queries);
+        }
+      } else if (!(0, _isEmpty2.default)(queries)) {
+        (0, _set2.default)(body, 'query', queries);
+      }
+
+      if (!(0, _isEmpty2.default)(aggregations)) {
+        (0, _set2.default)(body, 'aggs', aggregations);
       }
 
       return body;
@@ -180,7 +213,7 @@ var BodyBuilder = function () {
     key: '_filter',
     value: function _filter(boolType, filterType) {
       var klass = _filters2.default[filterType];
-      var newFilter = undefined;
+      var newFilter = void 0;
 
       if (!klass) {
         throw new TypeError('Filter type ' + filterType + ' not found.');
@@ -253,7 +286,7 @@ var BodyBuilder = function () {
     key: '_query',
     value: function _query(boolType, queryType) {
       var klass = _queries2.default[queryType];
-      var newQuery = undefined;
+      var newQuery = void 0;
 
       if (!klass) {
         throw new TypeError('Query type ' + queryType + ' not found.');
@@ -330,7 +363,7 @@ var BodyBuilder = function () {
     key: 'aggregation',
     value: function aggregation(type) {
       var klass = _aggregations2.default[type];
-      var aggregation = undefined;
+      var aggregation = void 0;
 
       if (!klass) {
         throw new TypeError('Aggregation type ' + type + ' not found.');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -55,8 +55,8 @@ function mergeConcat(target) {
 function boolMerge(newObj, currentObj) {
   var boolType = arguments.length <= 2 || arguments[2] === undefined ? 'and' : arguments[2];
 
-  var boolCurrent = undefined;
-  var boolNew = undefined;
+  var boolCurrent = void 0;
+  var boolNew = void 0;
 
   // Only one, no need for bool.
   if ((0, _isEmpty2.default)(currentObj)) {

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,12 @@ export default class BodyBuilder {
    * @returns {Object} Query body.
    */
   build() {
+    let v = arguments[0];
+    if (!_.isUndefined(v) || v === 'v2') return this._buildV2();
+    return this._buildV1();
+  }
+
+  _buildV1() {
     let body = _.clone(this._body)
     const filters = this._filters
     const queries = this._queries
@@ -45,6 +51,29 @@ export default class BodyBuilder {
 
     if (!_.isEmpty(aggregations)) {
       _.set(body, 'aggregations', aggregations)
+    }
+
+    return body
+  }
+
+  _buildV2() {
+    let body = _.clone(this._body)
+    const filters = this._filters
+    const queries = this._queries
+    const aggregations = this._aggregations
+
+    if (!_.isEmpty(filters)) {
+      _.set(body, 'query.bool.filter', filters)
+      if (!_.isEmpty(queries)) {
+        _.set(body, 'query.bool.must', queries)
+      }
+
+    } else if (!_.isEmpty(queries)) {
+      _.set(body, 'query', queries)
+    }
+
+    if (!_.isEmpty(aggregations)) {
+      _.set(body, 'aggs', aggregations)
     }
 
     return body

--- a/src/index.js
+++ b/src/index.js
@@ -26,9 +26,8 @@ export default class BodyBuilder {
    *
    * @returns {Object} Query body.
    */
-  build() {
-    let v = arguments[0];
-    if (!_.isUndefined(v) || v === 'v2') return this._buildV2();
+  build(version) {
+    if (!_.isUndefined(version) && version === 'v2') return this._buildV2();
     return this._buildV1();
   }
 

--- a/test/index-es-2x.js
+++ b/test/index-es-2x.js
@@ -1,0 +1,385 @@
+import BodyBuilder from '../src/index'
+import {expect} from 'chai'
+
+describe('BodyBuilder ES 2x', () => {
+
+  it('should default to empty query', () => {
+    let result = new BodyBuilder().build()
+    expect(result).to.eql({})
+  })
+
+  it('should return a copy of body when build', () => {
+    let body = new BodyBuilder()
+    let result1 = body.build('v2')
+    let result2 = body.build('v2')
+    expect(result1).to.not.equal(result2)
+  })
+
+  it('should use default sort direction', () => {
+    let result = new BodyBuilder().sort('timestamp').build('v2')
+    expect(result).to.eql({
+      sort: {
+        timestamp: {
+          order: 'asc'
+        }
+      }
+    })
+  })
+
+  it('should set a sort direction', () => {
+    let result = new BodyBuilder().sort('timestamp', 'desc').build('v2')
+    expect(result).to.eql({
+      sort: {
+        timestamp: {
+          order: 'desc'
+        }
+      }
+    })
+  })
+
+  it('should overwrite the sort direction', () => {
+    let result = new BodyBuilder().sort('timestamp', 'desc')
+                                  .sort('timestamp', 'asc')
+                                  .build('v2')
+    expect(result).to.eql({
+      sort: {
+        timestamp: {
+          order: 'asc'
+        }
+      }
+    })
+  })
+
+  it('should set a from value', () => {
+    let result = new BodyBuilder().from(25).build('v2')
+    expect(result).to.eql({
+      from: 25
+    })
+  })
+
+  it('should set a size value', () => {
+    let result = new BodyBuilder().size(25).build('v2')
+    expect(result).to.eql({
+      size: 25
+    })
+  })
+
+  it('should set a raw option', () => {
+    let result = new BodyBuilder().rawOption('_sourceExclude', 'bigfield')
+                                  .build('v2')
+    expect(result).to.eql({
+      _sourceExclude: 'bigfield'
+    })
+  })
+
+  it('should add a filter', () => {
+    let result = new BodyBuilder().filter('term', 'user', 'kimchy')
+                                  .build('v2')
+    expect(result).to.eql({
+      query: {
+        bool: {
+          filter: {
+            term: {user: 'kimchy'}
+          }
+        }
+      }
+    })
+  })
+
+  it('should add a filter with from and size', () => {
+    let result = new BodyBuilder().filter('term', 'user', 'kimchy')
+                                  .size(25)
+                                  .from(100)
+                                  .build('v2')
+    expect(result).to.eql({
+      size: 25,
+      from: 100,
+      query: {
+        bool: {
+          filter: {
+            term: {user: 'kimchy'}
+          }
+        }
+      }
+    })
+  })
+
+  it('should add two filters using bool filter ES 2x', () => {
+    let result = new BodyBuilder().filter('term', 'user', 'kimchy')
+                                  .filter('term', 'user', 'herald')
+                                  .build('v2')
+    expect(result).to.eql({
+      query: {
+        bool: {
+          filter: {
+            bool: {
+              must: [
+                {term: {user: 'kimchy'}},
+                {term: {user: 'herald'}}
+              ]
+            }
+          }
+        }
+      }
+    })
+  })
+
+  it('should add three filters using bool filter ES 2x', () => {
+    let result = new BodyBuilder().filter('term', 'user', 'kimchy')
+                                  .filter('term', 'user', 'herald')
+                                  .filter('term', 'user', 'johnny')
+                                  .build('v2')
+    expect(result).to.eql({
+      query: {
+        bool: {
+          filter: {
+            bool: {
+              must: [
+                {term: {user: 'kimchy'}},
+                {term: {user: 'herald'}},
+                {term: {user: 'johnny'}}
+              ]
+            }
+          }
+        }
+      }
+    })
+  })
+
+  it('should add an or filter using bool filter ES 2x', () => {
+    let result = new BodyBuilder().filter('term', 'user', 'kimchy')
+                                  .orFilter('term', 'user', 'herald')
+                                  .build('v2')
+    expect(result).to.eql({
+      query: {
+        bool: {
+          filter: {
+            bool: {
+              must: [
+                {term: {user: 'kimchy'}}
+              ],
+              should: [
+                {term: {user: 'herald'}}
+              ]
+            }
+          }
+        }
+      }
+    })
+  })
+
+  it('should add and, not, and or filters using bool filter ES 2x', () => {
+    let result = new BodyBuilder().filter('term', 'user', 'kimchy')
+                                  .filter('term', 'user', 'herald')
+                                  .orFilter('term', 'user', 'johnny')
+                                  .notFilter('term', 'user', 'cassie')
+                                  .build('v2')
+    expect(result).to.eql({
+      query: {
+        bool: {
+          filter: {
+            bool: {
+              must: [
+                {term: {user: 'kimchy'}},
+                {term: {user: 'herald'}}
+              ],
+              should: [
+                {term: {user: 'johnny'}}
+              ],
+              must_not: [
+                {term: {user: 'cassie'}}
+              ]
+            }
+          }
+        }
+      }
+    })
+  })
+
+  it('should throw if filter type not found ES 2x', () => {
+    let fn = () => {
+      new BodyBuilder().filter('unknown', 'user', 'kimchy').build('v2')
+    }
+    expect(fn).to.throw('Filter type unknown not found.')
+  })
+
+  it('should add an aggregation ES 2x', () => {
+    let result = new BodyBuilder().aggregation('terms', 'user').build('v2')
+    expect(result).to.eql({
+      aggs: {
+        agg_terms_user: {
+          terms: {
+            field: 'user'
+          }
+        }
+      }
+    })
+  })
+
+  it('should add multiple aggregations ES 2x', () => {
+    let result = new BodyBuilder().aggregation('terms', 'user')
+                                  .aggregation('terms', 'name')
+                                  .build('v2')
+    expect(result).to.eql({
+      aggs: {
+        agg_terms_user: {
+          terms: {
+            field: 'user'
+          }
+        },
+        agg_terms_name: {
+          terms: {
+            field: 'name'
+          }
+        }
+      }
+    })
+  })
+
+  it('should add an aggregation and a filter ES 2x', () => {
+    let result = new BodyBuilder().filter('term', 'user', 'kimchy')
+                                  .agg('terms', 'user')
+                                  .build('v2')
+    expect(result).to.eql({
+      query: {
+        bool: {
+          filter: {
+            term: {user: 'kimchy'}
+          }
+        }
+      },
+      aggs: {
+        agg_terms_user: {
+          terms: {
+            field: 'user'
+          }
+        }
+      }
+    })
+  })
+
+  it('should add a query ES 2x', () => {
+    let result = new BodyBuilder().query('match', 'message', 'this is a test')
+                                  .build('v2')
+    expect(result).to.eql({
+      query: {
+        match: {
+          message: 'this is a test'
+        }
+      }
+    })
+  })
+
+  it('should add multiple queries ES 2x', () => {
+    let result = new BodyBuilder().query('match', 'message', 'this is a test')
+                                  .andQuery('match', 'message', 'another test')
+                                  .addQuery('match', 'title', 'test')
+                                  .build('v2')
+    expect(result).to.eql({
+      query: {
+        bool: {
+          must: [
+            {match: {message: 'this is a test'}},
+            {match: { message: 'another test'}},
+            {match: {title: 'test'}}
+          ]
+        }
+      }
+    })
+  })
+
+  it('should support starting with a should query ES 2x', () => {
+    let result = new BodyBuilder().orQuery('match', 'message', 'this is a test')
+                                  .build('v2')
+    expect(result).to.eql({
+      query: {
+        bool: {
+          should: [
+            {match: {message: 'this is a test'}}
+          ]
+        }
+      }
+    })
+  })
+
+  it('should support starting with multiple should queries ES 2x', () => {
+    let result = new BodyBuilder().orQuery('match', 'message', 'this is a test')
+                                  .orQuery('match', 'message', 'another test')
+                                  .build('v2')
+    expect(result).to.eql({
+      query: {
+        bool: {
+          should: [
+            {match: {message: 'this is a test'}},
+            {match: { message: 'another test'}}
+          ]
+        }
+      }
+    })
+  })
+
+  it('should add and, not, and or queries using bool query ES 2x', () => {
+    let result = new BodyBuilder().query('term', 'user', 'kimchy')
+                                  .query('term', 'user', 'herald')
+                                  .orQuery('term', 'user', 'johnny')
+                                  .notQuery('term', 'user', 'cassie')
+                                  .build('v2')
+    expect(result).to.eql({
+      query: {
+        bool: {
+          must: [
+            {term: {user: 'kimchy'}},
+            {term: {user: 'herald'}}
+          ],
+          should: [
+            {term: {user: 'johnny'}}
+          ],
+          must_not: [
+            {term: {user: 'cassie'}}
+          ]
+        }
+      }
+    })
+  })
+
+  it('should add a query with a filter ES 2x', () => {
+    let result = new BodyBuilder().query('match', 'message', 'this is a test')
+                                  .filter('term', 'user', 'kimchy')
+                                  .build('v2')
+    expect(result).to.eql({
+      query: {
+        bool: {
+          must: {
+            match: {
+              message: 'this is a test'
+            }
+          },
+          filter: {
+            term: {user: 'kimchy'}
+          }
+        }
+      }
+    })
+  })
+
+  it('should add multiples different queries ES 2x', () => {
+    let result = new BodyBuilder().query('match', 'title', 'quick')
+                                  .notQuery('match', 'title', 'lazy')
+                                  .orQuery('match', 'title', 'brown')
+                                  .orQuery('match', 'title', 'dog')
+                                  .build()
+    expect(result).to.eql({
+      "query": {
+        "bool": {
+          "must":     [  { "match": { "title": "quick" }} ],
+          "must_not": [  { "match": { "title": "lazy"  }} ],
+          "should":   [
+                        { "match": { "title": "brown" }},
+                        { "match": { "title": "dog"   }}
+                      ]
+        }
+      }
+    })
+  })
+
+})


### PR DESCRIPTION
# Support for ElasticSearch 2.x query DSL generation

This pull request is to add support for ElasticSearch 2.x query generation based on [this issue](https://github.com/danpaz/bodybuilder/issues/2). 

In summary, to generate 2.x query DSL, one needs to pass a `v2` string parameter to tell _BodyBuilder_ to generate the correct query.

```
new BodyBuilder().query('match', 'message', 'this is a test')
                                  .filter('term', 'user', 'kimchy')
                                  .build('v2')
```

Above code will generate the following query

```
{
  query: {
    bool: {
      must: {
        match: {
          message: 'this is a test'
        }
      },
      filter: {
        term: {user: 'kimchy'}
      }
    }
  }
}
```
