### PR TITLE
Fix linter error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ export default class BodyBuilder {
 
   /**
    * Constructs the elasticsearch query body in its current state.
-   *
+   * @param  {String} version             Version to generate.
    * @returns {Object} Query body.
    */
   build(version) {


### PR DESCRIPTION
Why:
Lint error in index.js

This change addresses the need by:
Adding parameter in JSDoc comment on
`build` method.

This change affects the following:
