### PR TITLE
Fix query builder for 2.x

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -62,11 +62,15 @@ export default class BodyBuilder {
     const aggregations = this._aggregations
 
     if (!_.isEmpty(filters)) {
-      _.set(body, 'query.bool.filter', filters)
-      if (!_.isEmpty(queries)) {
-        _.set(body, 'query.bool.must', queries)
+      let filterBody = {};
+      let queryBody = {};
+      _.set(filterBody, 'query.bool.filter', filters)
+      if (!_.isEmpty(queries.bool)) {
+        _.set(queryBody, 'query.bool', queries.bool)
+      } else if (!_.isEmpty(queries)) {
+        _.set(queryBody, 'query.bool.must', queries)
       }
-
+      _.merge(body, filterBody, queryBody);
     } else if (!_.isEmpty(queries)) {
       _.set(body, 'query', queries)
     }

--- a/test/index-es-2x.js
+++ b/test/index-es-2x.js
@@ -362,6 +362,44 @@ describe('BodyBuilder ES 2x', () => {
     })
   })
 
+  it('should add queries with filters ES 2x', () => {
+    let result = new BodyBuilder().query('match', 'message', 'this is a test')
+                                  .andQuery('match', 'other', 'this is another test')
+                                  .filter('term', 'user', 'kimchy')
+                                  .filter('term', 'is_active', true)
+                                  .build('v2')
+    expect(result).to.eql({
+      query: {
+        bool: {
+          must: [
+            {
+              match: {
+                message: 'this is a test'
+              }
+            },
+            {
+              match: {
+                other: 'this is another test'
+              }
+            }
+          ],
+          filter: {
+            bool: {
+              must: [
+                {
+                  term: {user: 'kimchy'}
+                },
+                {
+                  term: {is_active: true}
+                }
+              ]
+            }
+          }
+        }
+      }
+    })
+  })
+
   it('should add multiples different queries ES 2x', () => {
     let result = new BodyBuilder().query('match', 'title', 'quick')
                                   .notQuery('match', 'title', 'lazy')


### PR DESCRIPTION
Why:
The build was not function as it supposed to be
due to the use of `_.set(body, 'query.bool.must', query)`
when building a query with filter. It build incorrect
query when the query was a combination, which build
something like `bool: {must:[...]}`. Hence the
end result was:

```
{
query: {
bool: {
filter: {
// some filters
        }
      },
must: {
    bool: { must: [...] }
      }
       }
}
```

This change addresses the need by:
Build query for filters and queries separately
and merge it after that.

This change affects the following:
